### PR TITLE
Fix issue that AR breaks distinct count on SQLite

### DIFF
--- a/app/models/impressionist/impressionable.rb
+++ b/app/models/impressionist/impressionable.rb
@@ -42,7 +42,7 @@ module Impressionist
       # Count all distinct impressions unless the :all filter is provided.
       distinct = options[:filter] != :all
       if Rails::VERSION::MAJOR >= 4
-        distinct ? imps.select(options[:filter]).distinct.count : imps.count
+        distinct ? imps.select(options[:filter]).distinct.count(:all) : imps.count
       else
         distinct ? imps.count(options[:filter], :distinct => true) : imps.count
       end


### PR DESCRIPTION
There's a issue that calling `COUNT` and `DISTINCT` on multiple columns breaks the query. Fixed by supplying `:all` to the `count` function.